### PR TITLE
Criar e configurar a tela de resultado do IMC

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.comunidadedevspace.imc"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.comunidadedevspace.imc"
@@ -41,6 +41,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.10.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    implementation("androidx.activity:activity:1.10.0")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,9 @@
         android:theme="@style/Theme.Calculadoraimc"
         tools:targetApi="31">
         <activity
+            android:name=".ResultActivity"
+            android:exported="false" />
+        <activity
             android:name=".MainActivity"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/com/comunidadedevspace/imc/MainActivity.kt
+++ b/app/src/main/java/com/comunidadedevspace/imc/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.comunidadedevspace.imc
 
+import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.widget.Button
@@ -35,7 +36,15 @@ class MainActivity : AppCompatActivity() {
                 val alturaQ2 = altura * altura
                 val resultado = peso / alturaQ2
 
+                val intent = Intent(this, ResultActivity::class.java)
+                intent.putExtra(KEY_RESULT_IMC,resultado)
+                startActivity(intent)
+
                 println("Luiz Barth clicou no botão" + resultado)
+                // Navegar para proxima tela
+                // Criar o layout da proxima tela
+                // Passar os dados (resultado) para proxima tela
+                // Intent - Classe do Android
             }
         }
     }

--- a/app/src/main/java/com/comunidadedevspace/imc/ResultActivity.kt
+++ b/app/src/main/java/com/comunidadedevspace/imc/ResultActivity.kt
@@ -1,0 +1,42 @@
+package com.comunidadedevspace.imc
+
+import android.os.Bundle
+import android.widget.TextView
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+
+const val KEY_RESULT_IMC = "ResultActivity.KEY_IMC"
+
+class ResultActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContentView(R.layout.activity_result)
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            insets
+        }
+
+        val result = intent.getFloatExtra(KEY_RESULT_IMC, 0f)
+
+        val classificacao: String = if(result<=18.5f){
+            "MAGRESA"
+        }else if(result<=24.9f){
+            "NORMAL"
+        }else if(result<=29.9f){
+            "SOBREPESO"
+        }else if(result<=39.9f){
+            "OBESIDADE"
+        }else{
+            "OBESIDADE GRAVE"
+        }
+
+        val tvResult = findViewById<TextView>(R.id.tv_result)
+        val tvClassificacao = findViewById<TextView>(R.id.tv_classificacao)
+        tvResult.text = result.toString()
+        tvClassificacao.text = classificacao
+    }
+}

--- a/app/src/main/res/layout/activity_result.xml
+++ b/app/src/main/res/layout/activity_result.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    tools:context=".ResultActivity">
+
+    <TextView
+        android:id="@+id/tv_result"
+        android:maxLength="5"
+        android:textSize="60sp"
+        android:textStyle="bold"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:text="result" />
+
+    <TextView
+        android:id="@+id/tv_classificacao_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="A classificação do seu IMC é:" />
+
+    <TextView
+        android:id="@+id/tv_classificacao"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"
+        tools:text="Class" />
+</LinearLayout>


### PR DESCRIPTION
## O que foi alterado?
Tela principal com valores exemplo:
<img src="https://github.com/user-attachments/assets/4aa3986c-5622-4fd9-aadc-f8554dec2870" width = 260/>
- Criada uma segunda tela onde aparece o resultado do calculo do IMC
- Resgate do resultado obtido no calculo do IMC
- Adicionadas as caixas de texto para exibir o resultado do IMC
- Adicionada a logica para determinação da classificação do IMC do usuário 
- Tela do resultado do IMC:
<img src="https://github.com/user-attachments/assets/2c53005b-c766-45a0-adc3-382e6c7f619f" width=260/>
